### PR TITLE
Fix broken monitoring tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 google-api-python-client
 google-cloud-monitoring
 psutil
+grpcio-tools
 requests


### PR DESCRIPTION
`quay.io/broadinstitute/cromwell-monitor` does not work.
That requires a Python package `grpcio` to be installed.

Added `grpcio-tools` to PIP requirements and rebuilt a docker image.
New docker image with `grpc` installed: `leepc12/cromwell-monitor:test`

Then it worked fine.
